### PR TITLE
create a new http.Client if nil

### DIFF
--- a/client.go
+++ b/client.go
@@ -53,7 +53,7 @@ func New(v4s *v4.Signer, client *http.Client, service string, region string) (*h
 	case region == "":
 		return nil, MissingRegionError{}
 	case c == nil:
-		c = http.DefaultClient
+		c = &http.Client{}
 	}
 	s := &Signer{
 		transport: c.Transport,


### PR DESCRIPTION
Create a new http.Client if the parameter is nil, instead of using http.DefaultClient.
 The comment suggests this although it was not done.

This can trip up people who are using the default client for accessing servers other than AWS service ones.  